### PR TITLE
Add default initializer for ZingleConfig

### DIFF
--- a/Zingle/Zingle/Source/Zingle.swift
+++ b/Zingle/Zingle/Source/Zingle.swift
@@ -9,6 +9,7 @@
 import UIKit
 
 public class ZingleConfig {
+    public init() {}
     ///Set delay to hide Zingle. Default: 2.0.
     public var delay: TimeInterval = 2.0
     ///Set duration of Zingle visible animation. Default: 0.3.


### PR DESCRIPTION
Without the default initalizer, Swift will complain that the ZingleConfig initializer is inaccessible due to internal protection level

![Screenshot 2019-11-22 at 9 18 50 pm](https://user-images.githubusercontent.com/4982099/69461197-e56ddc00-0d6d-11ea-869d-168fa1331bdb.jpg)
